### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -16,7 +16,7 @@ require_once(DOKU_PLUGIN.'action.php');
  */
 class action_plugin_odp extends DokuWiki_Action_Plugin {
 
-    function register($controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, 'handle_cache_prepare');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -52,7 +52,7 @@ class syntax_plugin_odp extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         // Export button
         if ($match == '~~ODP~~') { return array(); }
         // Extended info
@@ -72,7 +72,7 @@ class syntax_plugin_odp extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         global $ID, $REV;
         if (!$data) { // Export button
             if($format != 'xhtml') return false;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
